### PR TITLE
GH-9 Add possibility to choose a sub-set of backends per component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+
+- Possibility of selecting backends per component
+
 ## [0.9.2]
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ export default withVrpc(MyComponent)
 > You can use simple `try/catch` statements, VRPC forwards potential exceptions
 > on the backend for you.
 
+> **NOTE 3**
+>
+> You may select only one or a subset of your backends for a specific component.
+> Simply provide a string or an array of strings specifying the
+> corresponding backends as first argument of the `withVrpc` function.
+> ```javascript
+> export default withVrpc('backend1', MyComponent)
+> ```
+> This will limit the re-rendering of `MyComponent` solely to changes observed
+> in `backend1` drastically improving performance when using several backends.
 
 For all details, please visit: https://vrpc.io, or
 https://github.com/bheisen/vrpc


### PR DESCRIPTION
Currently, every component automatically "subscribes" (in a Context.Consumer sense) to all available backends as defined by `createVrpcProvider`. This leads leads to a re-rendering of the component whenever changes on any of the defined backends are encountered. For applications using many backends but utilizing components needing only one or few of those at a time this behavior is a performance hit.