### PR TITLE
fixed nesting level of injected vrpc prop

### DIFF
--- a/lib/react-vrpc.js
+++ b/lib/react-vrpc.js
@@ -832,7 +832,7 @@ var VrpcBackendMaker = function (_Component) {
       if (index === -1) {
         return _react2.default.createElement(
           vrpcClientContext.Provider,
-          { value: (0, _extends3.default)({}, this.state.vrpc) },
+          { value: { vrpc: this.state.vrpc } },
           this.renderProviders(children, index + 1)
         );
       }

--- a/src/react-vrpc.js
+++ b/src/react-vrpc.js
@@ -245,7 +245,7 @@ class VrpcBackendMaker extends Component {
   renderProviders (children, index = -1) {
     if (index === -1) {
       return (
-        <vrpcClientContext.Provider value={{ ...this.state.vrpc }}>
+        <vrpcClientContext.Provider value={ { vrpc: this.state.vrpc } }>
           {this.renderProviders(children, index + 1)}
         </vrpcClientContext.Provider>
       )


### PR DESCRIPTION
# Changes proposed in the pull request:

- Properly injecting `vrpc` and `client`, `loading` and `error` as nested props

closes #27 
