### PR TITLE
added `className` as option to `callAll`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+
+- API of `callAll` function to support provisioning of an explicit `className`
+
 ## [1.1.1] - 03 Feb 2021
 
 ### Fixed

--- a/src/react-vrpc.js
+++ b/src/react-vrpc.js
@@ -215,12 +215,12 @@ class VrpcBackendMaker extends Component {
             return instance
           },
           delete: async (id) => client.delete(id, { agent }),
-          callAll: async (functionName, ...args) => {
+          callAll: async (functionName, { args, className }) => {
             return client.callAll({
               agent,
               functionName,
               args,
-              className: backendClassName
+              className: className || backendClassName,
             })
           },
           ids: []


### PR DESCRIPTION
# Changes proposed in the pull request:

Changed API of `callAll` function to support provisioning of an explicit `className`

closes #34 
